### PR TITLE
Turtles can read sign text.

### DIFF
--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -25,6 +25,7 @@ import dan200.computercraft.shared.network.NetworkHandler;
 import dan200.computercraft.shared.peripheral.commandblock.CommandBlockPeripheral;
 import dan200.computercraft.shared.peripheral.modem.wireless.WirelessNetwork;
 import dan200.computercraft.shared.turtle.FurnaceRefuelHandler;
+import dan200.computercraft.shared.turtle.SignInspectHandler;
 import dan200.computercraft.shared.util.TickScheduler;
 
 import net.minecraft.block.entity.BlockEntity;
@@ -107,6 +108,7 @@ public final class ComputerCraftProxyCommon {
 
         TurtleEvent.EVENT_BUS.register(FurnaceRefuelHandler.INSTANCE);
         TurtleEvent.EVENT_BUS.register(new TurtlePermissions());
+        TurtleEvent.EVENT_BUS.register(new SignInspectHandler());
     }
 
     public static void registerLoot() {

--- a/src/main/java/dan200/computercraft/shared/turtle/SignInspectHandler.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/SignInspectHandler.java
@@ -1,0 +1,25 @@
+package dan200.computercraft.shared.turtle;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.eventbus.Subscribe;
+
+import dan200.computercraft.api.turtle.event.TurtleBlockEvent;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.SignBlockEntity;
+
+public class SignInspectHandler {
+    @Subscribe
+    public void onTurtleInspect(TurtleBlockEvent.Inspect event) {
+        BlockEntity be = event.getWorld().getBlockEntity(event.getPos());
+        if (be instanceof SignBlockEntity) {
+            SignBlockEntity sbe = (SignBlockEntity)be;
+            Map<Integer, String> textTable = new HashMap<>();
+            for(int k = 0; k < 4; k++) {
+                textTable.put(k+1, sbe.getTextOnRow(k).asString());
+            }
+            event.getData().put("text", textTable);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3 

The extension API is already there (should've checked, d'oh!)

Now we use it to implement the sign text feature.

I wasn't sure whether CC should use its own extension API, or just hardcode sign support in `TurtleInspectCommand`.